### PR TITLE
fix: Codex compatibility — 4 issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - 2026-04-09
+
+### Added
+
+- `--continue-on-error` flag for `build.mjs` to skip failed skills (#24)
+- `--exclude <name>` flag for `build.mjs` to exclude specific skills (#24)
+- Lint rule IDs in `validate-skills.mjs` output for actionable debugging (#25)
+- CLAUDE.md project rules
+
+### Fixed
+
+- Upgrade pnpm from 10.8.1 to 10.30.3 (unblocks corporate proxies) (#22)
+- Relax `engines.node` from `>=22` to `>=20` for broader compatibility (#23)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# Project Rules — SkillsCraft Hub
+
+## Build & Tooling
+
+- Use latest GPG for commit signing (`brew install gnupg` or system package manager)
+- pnpm version is pinned via `packageManager` field — update it when upgrading pnpm
+- Minimum Node version is 20.0.0 — do not raise without justification
+- Run `pnpm build && pnpm test` before pushing
+
+## Build Pipeline
+
+- `build.mjs` runs 5 phases: validate → copy → generate index → copy docs → SEO
+- Use `--continue-on-error` to skip failed skills during build
+- Use `--exclude <name>` to exclude specific skills from the build
+- Security scanner (`security-scan.mjs`) runs 13 rules — critical/high findings fail the build
+
+## Code Quality
+
+- ESLint 9+ flat config — run `pnpm lint` before committing
+- Prettier formatting is enforced — run `pnpm format` before committing
+- Skill scripts use their own language toolchains (Java, Python, etc.)
+
+## Skills
+
+- Skills live in `skills/skill/<name>/` with a `SKILL.md` frontmatter + markdown body
+- `.skillignore` controls which files are excluded from distribution
+- Validation output shows lint rule IDs for actionable debugging
+
+## GitHub Pages
+
+- Docs live in `docs/` and deploy via `.github/workflows/pages.yml`
+- Static pages: index.html (landing), gallery.html (browser), tutorial.html (guide)
+- Update docs when adding skills or changing build features
+
+## PR Workflow
+
+- Create GitHub issues before implementing fixes
+- Branch naming: `fix/`, `feat/`, `chore/` prefixes
+- Let CI pipeline pass before merging
+- Update changelog and release notes with every PR

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     }
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20.0.0"
   },
-  "packageManager": "pnpm@10.8.1"
+  "packageManager": "pnpm@10.30.3"
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -43,6 +43,18 @@ const require = createRequire(import.meta.url);
 const core = require("@skillscraft/core");
 const { parseSkill, validateSkill, lintSkill } = core;
 
+// CLI flags
+const args = process.argv.slice(2);
+const continueOnError = args.includes("--continue-on-error");
+const excludeIdx = args.indexOf("--exclude");
+const excludeNames = new Set();
+if (excludeIdx !== -1) {
+  // Collect all names after --exclude until next flag
+  for (let i = excludeIdx + 1; i < args.length && !args[i].startsWith("--"); i++) {
+    excludeNames.add(args[i]);
+  }
+}
+
 // skillignore — inline implementation (SDK exports these in >=0.10, not in 0.9.0)
 const DEFAULT_IGNORE = [
   "CODEOWNERS", "CHANGELOG.md", "CHANGELOG", "RELEASE-NOTES.md",
@@ -639,9 +651,21 @@ async function main() {
     process.exit(1);
   }
 
-  const skillDirs = readdirSync(SKILLS_SRC, { withFileTypes: true })
+  const allSkillDirs = readdirSync(SKILLS_SRC, { withFileTypes: true })
     .filter((d) => d.isDirectory())
     .map((d) => d.name);
+
+  const skillDirs = allSkillDirs.filter((name) => {
+    if (excludeNames.has(name)) {
+      console.log(`  ⊘ ${name} (excluded via --exclude)`);
+      return false;
+    }
+    return true;
+  });
+
+  if (excludeNames.size > 0) {
+    console.log(`  Excluded ${excludeNames.size} skill(s)\n`);
+  }
 
   console.log(`Found ${skillDirs.length} skill(s)\n`);
 
@@ -696,8 +720,13 @@ async function main() {
   }
 
   if (failed > 0) {
-    console.error(`\n${failed} skill(s) failed validation. Build aborted.`);
-    process.exit(1);
+    if (continueOnError) {
+      console.warn(`\n⚠ ${failed} skill(s) failed validation — continuing (--continue-on-error)`);
+    } else {
+      console.error(`\n${failed} skill(s) failed validation. Build aborted.`);
+      console.error("Use --continue-on-error to skip failed skills, or --exclude <name> to exclude specific skills.");
+      process.exit(1);
+    }
   }
 
   console.log(`\n${validated.length} skill(s) validated\n`);

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -80,7 +80,10 @@ async function main() {
         const w = lint.diagnostics.length;
         if (w > 0) {
           warnings += w;
-          console.log(`  \u2713 ${relPath} (${w} lint warning(s))`);
+          const ruleIds = lint.diagnostics
+            .map((d) => d.rule || d.id || "unknown")
+            .join(", ");
+          console.log(`  \u2713 ${relPath} (${w} warning(s): ${ruleIds})`);
         } else {
           console.log(`  \u2713 ${relPath}`);
         }


### PR DESCRIPTION
## Summary
Addresses all 4 Codex compatibility test report items for skillscraft-hub:

- **#22** Upgrade pnpm from 10.8.1 to 10.30.3 (unblocks corporate proxies)
- **#23** Relax `engines.node` from `>=22` to `>=20`
- **#24** Add `--continue-on-error` and `--exclude <name>` flags to `build.mjs`
- **#25** Show lint rule IDs in `validate-skills.mjs` output

Also includes:
- CLAUDE.md project rules
- CHANGELOG.md created

## Test plan
- [ ] `pnpm install` works behind corporate proxy
- [ ] `pnpm build` works on Node 20
- [ ] `pnpm build -- --exclude hello-skill` excludes the skill
- [ ] `pnpm build -- --continue-on-error` continues past failures
- [ ] `pnpm validate` shows rule IDs like `(2 warnings: context-budget, description-quality)`
- [ ] CI pipeline passes